### PR TITLE
Fix hashtag search algorithm with prefix-based filtering

### DIFF
--- a/main.js
+++ b/main.js
@@ -359,7 +359,8 @@ ipcMain.handle("db-add-link", async (event, linkData) => {
     
     const enrichedLinkData = {
       ...linkData,
-      title: metadata.title,
+      // Only use metadata title if user didn't provide one
+      title: linkData.title && linkData.title.trim() !== '' ? linkData.title : metadata.title,
       domain: metadata.domain,
       favicon: isGitHub ? linkData.favicon : metadata.favicon,
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meowlink",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "🐱 MeowLink - Knowledge Collection App for Developers",
   "main": "main.js",
   "author": "Your Name <your.email@example.com>",

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -24,7 +24,7 @@
                     <img src="../assets/meowlink-icon.png" alt="MeowLink" class="logo-icon" 
                          onerror="this.style.display='none'">
                     MeowLink
-                    <div class="version">v0.1.0</div>
+                    <div class="version" id="version-display-legacy">v0.1.1</div>
                 </div>
             </div>
             
@@ -120,6 +120,16 @@
         </div>
     </div>
 
+    <script>
+        // 버전 정보 동적 로드
+        if (window.electronAPI && window.electronAPI.getVersion) {
+            const versionElement = document.getElementById('version-display-legacy')
+            const version = window.electronAPI.getVersion()
+            if (versionElement) {
+                versionElement.textContent = `v${version}`
+            }
+        }
+    </script>
     <script src="app.js"></script>
 </body>
 </html>

--- a/renderer/splash.html
+++ b/renderer/splash.html
@@ -197,11 +197,18 @@
             <div></div>
         </div>
         
-        <div class="version">v0.1.1</div>
+        <div class="version" id="version-display">v0.1.1</div>
         <div></div>
     </div>
 
     <script>
+        // 버전 정보 동적 로드
+        if (window.electronAPI && window.electronAPI.getVersion) {
+            const versionElement = document.getElementById('version-display')
+            const version = window.electronAPI.getVersion()
+            versionElement.textContent = `v${version}`
+        }
+
         // 스플래시 화면 자동 종료
         setTimeout(() => {
             if (window.electronAPI) {

--- a/src/App-new.tsx
+++ b/src/App-new.tsx
@@ -59,13 +59,24 @@ export default function App() {
     // Search filter
     if (searchQuery) {
       const query = searchQuery.toLowerCase()
-      const matchesTitle = link.title.toLowerCase().includes(query)
-      const matchesMemo = link.memo?.toLowerCase().includes(query)
-      const matchesTags = link.tags.some(tag => tag.toLowerCase().includes(query))
-      const matchesUrl = link.url.toLowerCase().includes(query)
       
-      if (!matchesTitle && !matchesMemo && !matchesTags && !matchesUrl) {
-        return false
+      // Check if it's a hashtag search (starts with #)
+      if (query.startsWith('#')) {
+        const tagQuery = query.slice(1) // Remove the # prefix
+        const matchesTags = link.tags.some(tag => tag.toLowerCase().includes(tagQuery))
+        if (!matchesTags) {
+          return false
+        }
+      } else {
+        // Regular search across all fields
+        const matchesTitle = link.title.toLowerCase().includes(query)
+        const matchesMemo = link.memo?.toLowerCase().includes(query)
+        const matchesTags = link.tags.some(tag => tag.toLowerCase().includes(query))
+        const matchesUrl = link.url.toLowerCase().includes(query)
+        
+        if (!matchesTitle && !matchesMemo && !matchesTags && !matchesUrl) {
+          return false
+        }
       }
     }
 
@@ -198,7 +209,7 @@ export default function App() {
               <div className="relative flex-1 max-w-md">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
-                  placeholder="Search links, memos, or tags..."
+                  placeholder="Search links, memos, or tags... (use #tag for hashtag-only)"
                   value={searchQuery}
                   onChange={(e) => dispatch({ type: 'SET_SEARCH_QUERY', payload: e.target.value })}
                   className="pl-10"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,10 +117,18 @@ export default function App() {
       const correctedUrl = correctUrl(linkData.url)
       const urlObj = new URL(correctedUrl)
       
+      // For editing: always use the user's title (even if empty)
+      // For adding: use user's title if provided, otherwise auto-fetch
+      let finalTitle = linkData.title
+      if (!editingLink && (!linkData.title || linkData.title.trim() === '')) {
+        // Only auto-generate title for NEW links when user didn't provide one
+        finalTitle = `Loading... ${urlObj.hostname}`
+      }
+      
       const newLinkData = {
         ...linkData,
         url: correctedUrl,
-        title: linkData.title || `Loading... ${urlObj.hostname}`,
+        title: finalTitle,
         domain: urlObj.hostname,
         favicon: getFaviconUrl(urlObj.hostname, correctedUrl),
         tags: linkData.tags || [],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,13 +74,24 @@ export default function App() {
     // Search filter
     if (searchQuery) {
       const query = searchQuery.toLowerCase()
-      const matchesTitle = link.title.toLowerCase().includes(query)
-      const matchesMemo = link.memo?.toLowerCase().includes(query)
-      const matchesTags = link.tags.some(tag => tag.toLowerCase().includes(query))
-      const matchesUrl = link.url.toLowerCase().includes(query)
       
-      if (!matchesTitle && !matchesMemo && !matchesTags && !matchesUrl) {
-        return false
+      // Check if it's a hashtag search (starts with #)
+      if (query.startsWith('#')) {
+        const tagQuery = query.slice(1) // Remove the # prefix
+        const matchesTags = link.tags.some(tag => tag.toLowerCase().includes(tagQuery))
+        if (!matchesTags) {
+          return false
+        }
+      } else {
+        // Regular search across all fields
+        const matchesTitle = link.title.toLowerCase().includes(query)
+        const matchesMemo = link.memo?.toLowerCase().includes(query)
+        const matchesTags = link.tags.some(tag => tag.toLowerCase().includes(query))
+        const matchesUrl = link.url.toLowerCase().includes(query)
+        
+        if (!matchesTitle && !matchesMemo && !matchesTags && !matchesUrl) {
+          return false
+        }
       }
     }
 
@@ -245,7 +256,7 @@ export default function App() {
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
-                  placeholder="Search your bookmarks..."
+                  placeholder="Search bookmarks... (use #tag for hashtag-only search)"
                   value={searchQuery}
                   onChange={(e) => dispatch({ type: 'SET_SEARCH_QUERY', payload: e.target.value })}
                   className="pl-9 w-80 bg-card border-border/50 focus:bg-card focus:border-border"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -130,9 +130,9 @@ export function Sidebar({ onShowWelcome }: SidebarProps) {
                   key={tag}
                   variant="ghost"
                   onClick={() => {
-                    // When clicking a tag, search across all bookmarks and reset filter to 'all'
+                    // When clicking a tag, search only within tags using # prefix
                     dispatch({ type: 'SET_FILTER', payload: 'all' })
-                    dispatch({ type: 'SET_SEARCH_QUERY', payload: tag })
+                    dispatch({ type: 'SET_SEARCH_QUERY', payload: `#${tag}` })
                   }}
                   className="w-full justify-start gap-2 px-3 py-2 h-auto text-sm font-normal hover-hashtag text-sidebar-muted-foreground hover:text-sidebar-accent-foreground transition-colors"
                 >

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -13,10 +13,10 @@ export function getAppVersion(): string {
     }
     
     // Fallback - this will be updated when package.json is updated
-    return '0.1.0'
+    return '0.1.1'
   } catch (error) {
     console.warn('Could not get app version:', error)
-    return '0.1.0'
+    return '0.1.1'
   }
 }
 


### PR DESCRIPTION
## Summary
  - Fixed illogical hashtag search behavior where clicking sidebar hashtags returned mixed results
  - Implemented prefix-based search: `#tag` searches only within hashtags, regular search works across
   all fields
  - Enhanced user experience with intuitive search guidance

  ## Changes Made
  - **Smart Search Logic**: Added `#` prefix detection for hashtag-only filtering
  - **Sidebar Integration**: Hashtag clicks now trigger precise tag-only search using `#TAGNAME`
  - **User Guidance**: Updated placeholder text to explain `#tag` syntax
  - **Cross-Component**: Applied fix to both `App.tsx` and `App-new.tsx` for consistency

  ## Test Plan
  - [x] Compile React components without errors
  - [x] App starts successfully in development mode
  - [ ] Test clicking sidebar hashtags returns only tagged links
  - [ ] Test manual `#react` search finds only React-tagged bookmarks
  - [ ] Test regular `react` search finds all content containing "react"
  - [ ] Verify placeholder text displays correctly

  ## Before/After Behavior
  **Before:** Clicking "REACT" hashtag → searches everywhere → finds links with "react" in title,
  memo, tags, AND URL
  **After:** Clicking "REACT" hashtag → searches `#REACT` → finds ONLY links tagged with REACT

  **Backward Compatible:** Regular typing still searches all fields as expected